### PR TITLE
fixed bug in ecc_fp.dart

### DIFF
--- a/lib/ecc/ecc_fp.dart
+++ b/lib/ecc/ecc_fp.dart
@@ -538,7 +538,7 @@ List<int> _windowNaf(int width, BigInteger k) {
 }
 
 Uint8List _x9IntegerToBytes( BigInteger s, int qLength ) {
-  Uint8List bytes = s.toByteArray();
+  Uint8List bytes = new Uint8List.fromList(s.toByteArray());
 
   if( qLength < bytes.length ) {
     return bytes.sublist( bytes.length-qLength );


### PR DESCRIPTION
`BigInteger.toByteArray()` doesn't seem to return a `Uint8List`. So it needs to be converted.

How thoroughly has ECDSA been tested? I'm currently writing some tests for Dartcoin, so a bug in cipher could make me waste a lot of time.
