### PR TITLE
Removed some unused code

### DIFF
--- a/lib/signers/ecdsa_signer.dart
+++ b/lib/signers/ecdsa_signer.dart
@@ -353,15 +353,3 @@ class _RandomKCalculator {
   }
 
 }
-
-
-
-
-String formatBytesAsHexString(Uint8List bytes) {
-  var result = new StringBuffer();
-  for( var i=0 ; i<bytes.lengthInBytes ; i++ ) {
-    var part = bytes[i];
-    result.write('${part < 16 ? '0' : ''}${part.toRadixString(16)}');
-  }
-  return result.toString();
-}


### PR DESCRIPTION
I didn't get any errors when removing this, so I think it's no longer required.

Besides, you can use `CryptoUtils.bytesToHex(List<int> bytes)` from `package:crypto` for this purpose.
