### PR TITLE
Remove a registry dependency in the Scrypt algorithm.

### DIFF
--- a/lib/key_derivators/scrypt.dart
+++ b/lib/key_derivators/scrypt.dart
@@ -11,6 +11,9 @@ import "package:cipher/api/ufixnum.dart";
 import "package:cipher/params/key_derivators/scrypt_parameters.dart";
 import "package:cipher/params/key_derivators/pbkdf2_parameters.dart";
 import "package:cipher/key_derivators/base_key_derivator.dart";
+import "package:cipher/key_derivators/pbkdf2.dart";
+import "package:cipher/macs/hmac.dart";
+import "package:cipher/digests/sha256.dart";
 
 /**
  * Implementation of SCrypt password based key derivation function. See the next link for info on how to choose N, r, and p:
@@ -57,7 +60,7 @@ class Scrypt extends BaseKeyDerivator {
     var XY = new Uint8List(256 * r);
     var V  = new Uint8List(128 * r * N);
 
-    var pbkdf2 = new KeyDerivator("SHA-256/HMAC/PBKDF2");
+    var pbkdf2 = new PBKDF2KeyDerivator(new HMac(new SHA256Digest(), 64));
 
     pbkdf2.init(new Pbkdf2Parameters(salt, 1, p * 128 * r));
     pbkdf2.deriveKey( passwd, 0, B, 0 );


### PR DESCRIPTION
I don't know how you usually deal with such a situation, but it's the first time that I got an exception from cipher because I don't use the cipher registry.
Personally, I don't think internal cipher code should rely on the registry.

I might be willing to find other similar cases and change them to a registryless version.
