### PR TITLE
Added hashCode and == operator to all params

### DIFF
--- a/lib/api/ecc.dart
+++ b/lib/api/ecc.dart
@@ -121,14 +121,15 @@ class ECPrivateKey extends ECAsymmetricKey implements PrivateKey {
   /// Create an ECC private key for the given d and domain parameters.
   ECPrivateKey(this.d, ECDomainParameters parameters) : super(parameters);
 
+  @override
   bool operator ==( other ) {
-    if( other==null ) return false;
-    if( other is! ECPrivateKey ) return false;
-    return (other.parameters==this.parameters) && (other.d==this.d);
+    if(other is! ECPrivateKey) return false;
+    return other.parameters == this.parameters && other.d == this.d;
   }
 
+  @override
   int get hashCode {
-    return parameters.hashCode+d.hashCode;
+    return parameters.hashCode ^ d.hashCode;
   }
 
 }
@@ -142,14 +143,15 @@ class ECPublicKey extends ECAsymmetricKey implements PublicKey {
   /// Create an ECC public key for the given Q and domain parameters.
   ECPublicKey( this.Q, ECDomainParameters parameters ) : super(parameters);
 
+  @override
   bool operator ==( other ) {
-    if( other==null ) return false;
-    if( other is! ECPublicKey ) return false;
-    return (other.parameters==this.parameters) && (other.Q==this.Q);
+    if(other is! ECPublicKey) return false;
+    return other.parameters == this.parameters && other.Q == this.Q;
   }
 
+  @override
   int get hashCode {
-    return parameters.hashCode+Q.hashCode;
+    return parameters.hashCode ^ Q.hashCode;
   }
 
 }
@@ -164,14 +166,15 @@ class ECSignature implements Signature {
 
   String toString() => "(${r.toString()},${s.toString()})";
 
+  @override
   bool operator ==(other) {
-    if( other==null ) return false;
-    if( other is! ECSignature ) return false;
-    return (other.r==this.r) && (other.s==this.s);
+    if(other is! ECSignature) return false;
+    return other.r == this.r && other.s == this.s;
   }
 
+  @override
   int get hashCode {
-    return r.hashCode+s.hashCode;
+    return r.hashCode ^ s.hashCode;
   }
 
 }

--- a/lib/ecc/ecc_base.dart
+++ b/lib/ecc/ecc_base.dart
@@ -7,6 +7,7 @@ library cipher.ecc.ecc_base;
 import "dart:typed_data";
 
 import 'package:bignum/bignum.dart';
+import "package:collection/equality.dart";
 import "package:cipher/api/ecc.dart";
 
 /// Implementation of [ECDomainParameters]
@@ -21,11 +22,32 @@ class ECDomainParametersImpl implements ECDomainParameters {
 
   ECDomainParametersImpl( this.domainName, this.curve, this.G, this.n, [this._h=null, this.seed=null] ) {
     if( _h==null ) {
-    _h = BigInteger.ONE;
+      _h = BigInteger.ONE;
     }
   }
 
   BigInteger get h => _h;
+
+  @override
+  int get hashCode {
+    return domainName.hashCode ^
+    curve.hashCode ^
+    (seed != null ? new ListEquality().hash(seed) : 0) ^
+    G.hashCode ^
+    n.hashCode ^
+    _h.hashCode;
+  }
+
+  @override
+  bool operator ==(ECDomainParameters other) {
+    if(other is! ECDomainParameters) return false;
+    return domainName == other.domainName &&
+    curve == other.curve &&
+    ( (seed == null && other.seed == null) || new ListEquality().equals(seed, other.seed) ) &&
+    G == other.G &&
+    n == other.n &&
+    _h == other._h;
+  }
 
 }
 
@@ -196,6 +218,17 @@ abstract class ECCurveBase implements ECCurve {
 
   BigInteger _fromArray( List<int> buf, int off, int length ) {
     return new BigInteger.fromBytes(1, buf.sublist(off, off+length));
+  }
+
+  @override
+  int get hashCode {
+    return _a.hashCode ^ _b.hashCode;
+  }
+
+  @override
+  bool operator ==(ECCurveBase other) {
+    if(other is! ECCurveBase) return false;
+    return _a == other._a && _b == other._b;
   }
 
 }

--- a/lib/ecc/ecc_fp.dart
+++ b/lib/ecc/ecc_fp.dart
@@ -321,13 +321,15 @@ class ECCurve extends ecc.ECCurveBase {
     return new ECPoint( this, x, beta, true );
   }
 
+  @override
   bool operator ==(other) {
     if( other is ECCurve ) {
-      return q==other.q && a==other.a && b==other.b;
+      return q == other.q && a == other.a && b == other.b;
     }
     return false;
   }
 
+  @override
   int get hashCode => a.hashCode ^ b.hashCode ^ q.hashCode;
 }
 

--- a/lib/params/asymmetric_key_parameter.dart
+++ b/lib/params/asymmetric_key_parameter.dart
@@ -13,6 +13,17 @@ abstract class AsymmetricKeyParameter<T extends AsymmetricKey> implements Cipher
 
   AsymmetricKeyParameter(this.key);
 
+  @override
+  int get hashCode {
+    return key.hashCode;
+  }
+
+  @override
+  bool operator ==(AsymmetricKeyParameter other) {
+    if(other is! AsymmetricKeyParameter) return false;
+    return key == other.key;
+  }
+
 }
 
 /// A [CipherParameters] to hold an asymmetric public key

--- a/lib/params/key_derivators/pbkdf2_parameters.dart
+++ b/lib/params/key_derivators/pbkdf2_parameters.dart
@@ -5,6 +5,7 @@
 library cipher.params.key_derivators.pbkdf2_parameters;
 
 import "dart:typed_data";
+import "package:collection/equality.dart";
 
 import "package:cipher/api.dart";
 
@@ -16,5 +17,18 @@ class Pbkdf2Parameters extends CipherParameters {
   final int desiredKeyLength;
 
   Pbkdf2Parameters(this.salt, this.iterationCount, this.desiredKeyLength);
+
+  @override
+  int get hashCode {
+    return iterationCount.hashCode ^ desiredKeyLength.hashCode ^ new ListEquality().hash(salt);
+  }
+
+  @override
+  bool operator ==(Pbkdf2Parameters other) {
+    if(other is! Pbkdf2Parameters) return false;
+    return iterationCount == other.iterationCount &&
+    desiredKeyLength == other.desiredKeyLength &&
+    new ListEquality().equals(salt, other.salt);
+  }
 
 }

--- a/lib/params/key_derivators/scrypt_parameters.dart
+++ b/lib/params/key_derivators/scrypt_parameters.dart
@@ -5,6 +5,7 @@
 library cipher.params.key_derivators.scrypt_parameters;
 
 import "dart:typed_data";
+import "package:collection/equality.dart";
 
 import "package:cipher/api.dart";
 
@@ -13,12 +14,26 @@ import "package:cipher/api.dart";
  */
 class ScryptParameters implements CipherParameters {
 
-    final int N;
-    final int r;
-    final int p;
-    final int desiredKeyLength;
-    final Uint8List salt;
+  final int N;
+  final int r;
+  final int p;
+  final int desiredKeyLength;
+  final Uint8List salt;
 
-    ScryptParameters( this.N, this.r, this.p, this.desiredKeyLength, this.salt );
+  ScryptParameters( this.N, this.r, this.p, this.desiredKeyLength, this.salt );
 
+  @override
+  int get hashCode {
+    return N.hashCode ^ r.hashCode ^ p.hashCode ^ desiredKeyLength.hashCode ^ new ListEquality().hash(salt);
+  }
+
+  @override
+  bool operator ==(ScryptParameters other) {
+    if(other is! ScryptParameters) return false;
+    return N == other.N &&
+        r == other.r &&
+        p == other.p &&
+        desiredKeyLength == other.desiredKeyLength &&
+        new ListEquality().equals(salt, other.salt);
+  }
 }

--- a/lib/params/key_generators/ec_key_generator_parameters.dart
+++ b/lib/params/key_generators/ec_key_generator_parameters.dart
@@ -20,4 +20,17 @@ class ECKeyGeneratorParameters extends KeyGeneratorParameters {
 
   ECDomainParameters get domainParameters => _domainParameters;
 
+  @override
+  int get hashCode {
+    return _domainParameters.hashCode;
+  }
+
+  @override
+  bool operator ==(ECKeyGeneratorParameters other) {
+    if(other is! ECKeyGeneratorParameters) return false;
+    // super.bitLength is included in the domain parameters,
+    // so should not be tested separately
+    return _domainParameters == other._domainParameters;
+  }
+
 }

--- a/lib/params/key_generators/key_generator_parameters.dart
+++ b/lib/params/key_generators/key_generator_parameters.dart
@@ -13,4 +13,15 @@ abstract class KeyGeneratorParameters implements CipherParameters {
 
   KeyGeneratorParameters(this.bitStrength);
 
+  @override
+  int get hashCode {
+    return bitStrength.hashCode;
+  }
+
+  @override
+  bool operator ==(KeyGeneratorParameters other) {
+    if(other is! KeyGeneratorParameters) return false;
+    return bitStrength == other.bitStrength;
+  }
+
 }

--- a/lib/params/key_parameter.dart
+++ b/lib/params/key_parameter.dart
@@ -6,6 +6,7 @@ library cipher.params.key_parameter;
 
 import "dart:typed_data";
 
+import "package:collection/equality.dart";
 import "package:cipher/api.dart";
 
 /// [CipherParameters] consisting of just a key of arbitrary length.
@@ -14,5 +15,16 @@ class KeyParameter extends CipherParameters {
   final Uint8List key;
   
   KeyParameter(this.key);
+
+  @override
+  int get hashCode {
+    return new ListEquality().hash(key);
+  }
+
+  @override
+  bool operator ==(KeyParameter other) {
+    if(other is! KeyParameter) return false;
+    return new ListEquality().equals(key, other.key);
+  }
   
 }

--- a/lib/params/padded_block_cipher_parameters.dart
+++ b/lib/params/padded_block_cipher_parameters.dart
@@ -20,4 +20,16 @@ class PaddedBlockCipherParameters<
 
   PaddedBlockCipherParameters( this.underlyingCipherParameters, this.paddingCipherParameters );
 
+  @override
+  int get hashCode {
+    return underlyingCipherParameters.hashCode ^ paddingCipherParameters.hashCode;
+  }
+
+  @override
+  bool operator ==(PaddedBlockCipherParameters other) {
+    if(other is! PaddedBlockCipherParameters) return false;
+    return underlyingCipherParameters == other.underlyingCipherParameters &&
+    paddingCipherParameters == other.paddingCipherParameters;
+  }
+
 }

--- a/lib/params/parameters_with_iv.dart
+++ b/lib/params/parameters_with_iv.dart
@@ -6,6 +6,7 @@ library cipher.params.parameters_with_iv;
 
 import "dart:typed_data";
 
+import "package:collection/equality.dart";
 import "package:cipher/api.dart";
 
 /**
@@ -18,5 +19,17 @@ class ParametersWithIV<UnderlyingParameters extends CipherParameters> implements
     final UnderlyingParameters parameters;
 
     ParametersWithIV( this.parameters, this.iv );
+
+    @override
+    int get hashCode {
+      return parameters.hashCode ^ new ListEquality().hash(iv);
+    }
+
+    @override
+    bool operator ==(ParametersWithIV other) {
+      if(other is! ParametersWithIV) return false;
+      return parameters == other.parameters &&
+      new ListEquality().equals(iv, other.iv);
+    }
 
 }

--- a/lib/params/parameters_with_random.dart
+++ b/lib/params/parameters_with_random.dart
@@ -13,4 +13,24 @@ class ParametersWithRandom<UnderlyingParameters extends CipherParameters> implem
 
   ParametersWithRandom(this.parameters,this.random);
 
+  //TODO hashCode and equals currently only check the runtimeType of the SecureRandom
+  //      is this enough?
+
+  /**
+   * Only the [runtimeType] of [random] is taken into account.
+   */
+  @override
+  int get hashCode {
+    return parameters.hashCode ^ random.runtimeType.hashCode;
+  }
+
+  /**
+   * Only the [runtimeType] of [random] is taken into account.
+   */
+  @override
+  bool operator ==(ParametersWithRandom other) {
+    if(other is! ParametersWithRandom) return false;
+    return parameters == other.parameters && random.runtimeType == other.random.runtimeType;
+  }
+
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ documentation: http://izaera.github.io/cipher/api/
 dependencies:
   bignum: '>=0.0.5 <0.1.0'
   fixnum: '>=0.9.0 <0.10.0'
+  collection: '>=0.9.1 <0.10.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.4 <2.0.0'
   browser: '>=0.9.0 <0.10.0'


### PR DESCRIPTION
I needed this for ScryptParams and decided to add it to all of them.

Only one still has an issue (I placed a TODO): ParametersWithRandom. For this param, I only took the runtimeType of the SecureRandom into account. Otherwise, I'd have to implement hashCodes and equals for all randoms as well, which would cascade in adding them to all block ciphers.

I know runtimeType is not enough. For now, I clearly documented this drawback so I hope it's ok.

I had to add dependency for package:collection to pubspec.