### PR TITLE
Stop resetting _underlyingCipher

### DIFF
--- a/lib/modes/cbc.dart
+++ b/lib/modes/cbc.dart
@@ -37,7 +37,7 @@ class CBCBlockCipher extends BaseBlockCipher {
     _cbcV.setAll( 0, _IV );
     _cbcNextV.fillRange( 0, _cbcNextV.length, 0 );
 
-    _underlyingCipher.reset();
+    //_underlyingCipher.reset();
   }
 
   void init(bool forEncryption, ParametersWithIV params) {


### PR DESCRIPTION
CBC mode is resetting the cipher, preventing it from being used, I believe. This is to test the fix.

**Note to izaera** I have no idea if this is a dangerous change. Commenting this line made my code work, and I'm not sure why it would be there, if it was just breaking the code. Was this an oversight, or is there a reason that this line was added?